### PR TITLE
Feature/allow directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ Function returns an object like this:
   "tags": ['R1', 'R2']
 }
 ```
+
+You can add path destination if you want to get git last commit information on another repository:
+```javascript
+var git = require('git-last-commit');
+
+git.getLastCommit(function(err, commit) {
+  // read commit object properties
+  console.log(commit);
+}, {dst: 'some/other/path'});
+```

--- a/source/index.js
+++ b/source/index.js
@@ -1,7 +1,14 @@
-var process = require('child_process');
+var process = require('child_process'),
+	options = {};
 
 function _command(command, callback) {
-	process.exec(command, {cwd: __dirname}, function(err, stdout, stderr) {
+	var dst = __dirname;
+
+	if(!!options && options.dst) {
+		dst = options.dst;
+	}
+
+	process.exec(command, {cwd: dst}, function(err, stdout, stderr) {
 		if (stdout === '') {
 			callback('this does not look like a git repo');
 			return;
@@ -22,7 +29,8 @@ var command =
 	' && git tag --contains HEAD';
 
 module.exports = {
-	getLastCommit : function(callback) {
+	getLastCommit : function(callback, _options) {
+		options = _options;
 		_command(command, function(err, res) {
 			if (err) {
 				callback(err);

--- a/test/unit.js
+++ b/test/unit.js
@@ -140,6 +140,19 @@ describe('feature: git-last-commit to return last commit info', function() {
 		});
 	});
 
+	it('should run the git command on given destination', function(done) {
+		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,this is the body,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\nR2\nR1');
+
+		git.getLastCommit(function(err, commit) {
+			expect(err).to.be.null;
+			expect(commit).to.be.ok;
+			expect(processExecMethod.args[0][1].cwd).to.be.ok;
+			expect(processExecMethod.args[0][1].cwd).to.be.equal('path/path/whatever');
+
+			done();
+		}, {dst: 'path/path/whatever'});
+	});
+
 	it('should handle error properly if this is not a git repo', function(done) {
 		processExecMethod.yields(null, '');
 


### PR DESCRIPTION
A nice option (and in my case, much needed one) will be to allow the user to specify a destination, if we need to probe another path last git information.
I've added this option, also with a test to retain the perfect 100% coverage :)
