### PR TITLE
Fix the parse when there is approved tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-last-commit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Read details of the last commit including tags",
   "main": "./source/index.js",
   "scripts": {

--- a/source/index.js
+++ b/source/index.js
@@ -44,24 +44,32 @@ module.exports = {
 				tags = a.slice(13 - a.length);
 			}
 
+			var shouldSkip = 0;
+			for(var i= 4; i<a.length; i++){
+				if(a[i].length > 0 && !isNaN(a[i])){
+					break;
+				}
+				shouldSkip++;	
+			}
+
 			callback(null, {
 				shortHash: a[0],
 				hash: a[1],
 				subject: a[2],
 				sanitizedSubject: a[3],
 				body: a[4],
-				authoredOn: a[5],
-				committedOn: a[6],
+				authoredOn: a[4+shouldSkip],
+				committedOn: a[5+shouldSkip],
 				author: {
-					name: a[7],
-					email: a[8],
+					name: a[6+shouldSkip],
+					email: a[7+shouldSkip],
 				},
 				committer: {
-					name: a[9],
-					email: a[10]
+					name: a[8+shouldSkip],
+					email: a[9+shouldSkip]
 				},
-				notes: a[11],
-				branch: a[12],
+				notes: a[10+shouldSkip],
+				branch: a[11+shouldSkip],
 				tags: tags
 			});
 		});

--- a/source/index.js
+++ b/source/index.js
@@ -24,7 +24,7 @@ function _command(command, callback) {
 }
 
 var command = 
-	'git log -1 --pretty=format:"%h,%H,%s,%f,%b,%at,%ct,%an,%ae,%cn,%ce,%N,"' + 
+	'git log -1 --pretty=format:"%h,%H,%s,%f,%at,%ct,%an,%ae,%cn,%ce,%N,"' + 
 	' && git rev-parse --abbrev-ref HEAD' + 
 	' && git tag --contains HEAD';
 
@@ -41,35 +41,27 @@ module.exports = {
 
 			var tags = [];
 			if (a[a.length-1] !== '') {
-				tags = a.slice(13 - a.length);
+				tags = a.slice(12 - a.length);
 			}
-
-			var shouldSkip = 0;
-			for(var i= 4; i<a.length; i++){
-				if(a[i].length > 0 && !isNaN(a[i])){
-					break;
-				}
-				shouldSkip++;	
-			}
-
+			
 			callback(null, {
 				shortHash: a[0],
 				hash: a[1],
 				subject: a[2],
 				sanitizedSubject: a[3],
-				body: a[4],
-				authoredOn: a[4+shouldSkip],
-				committedOn: a[5+shouldSkip],
+				// body: a[4],
+				authoredOn: a[4],
+				committedOn: a[5],
 				author: {
-					name: a[6+shouldSkip],
-					email: a[7+shouldSkip],
+					name: a[6],
+					email: a[7],
 				},
 				committer: {
-					name: a[8+shouldSkip],
-					email: a[9+shouldSkip]
+					name: a[8],
+					email: a[9]
 				},
-				notes: a[10+shouldSkip],
-				branch: a[11+shouldSkip],
+				notes: a[10],
+				branch: a[11],
 				tags: tags
 			});
 		});

--- a/test/unit.js
+++ b/test/unit.js
@@ -16,7 +16,7 @@ describe('feature: git-last-commit to return last commit info', function() {
 	});
 
 	it('should parse git commands fully', function(done) {
-		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,this is the body,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\nR2\nR1');
+		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\nR2\nR1');
 
 		git.getLastCommit(function(err, commit) {
 			expect(err).to.be.null;
@@ -25,7 +25,6 @@ describe('feature: git-last-commit to return last commit info', function() {
 			expect(commit.hash).to.be.equal('26e689d8769908329a145201be5081233c711663');
 			expect(commit.subject).to.be.equal('initial commit');
 			expect(commit.sanitizedSubject).to.be.equal('initial-commit');
-			expect(commit.body).to.be.equal('this is the body');
 			expect(commit.authoredOn).to.be.equal('1437984178');
 			expect(commit.committedOn).to.be.equal('1437984179');
 			expect(commit.author.name).to.be.equal('Author1');
@@ -41,7 +40,7 @@ describe('feature: git-last-commit to return last commit info', function() {
 	});
 
 	it('should parse git commands when commit has no notes', function(done) {
-		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,this is the body,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,\nmaster\nR2\nR1');
+		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,\nmaster\nR2\nR1');
 
 		git.getLastCommit(function(err, commit) {
 			expect(err).to.be.null;
@@ -50,7 +49,6 @@ describe('feature: git-last-commit to return last commit info', function() {
 			expect(commit.hash).to.be.equal('26e689d8769908329a145201be5081233c711663');
 			expect(commit.subject).to.be.equal('initial commit');
 			expect(commit.sanitizedSubject).to.be.equal('initial-commit');
-			expect(commit.body).to.be.equal('this is the body');
 			expect(commit.authoredOn).to.be.equal('1437984178');
 			expect(commit.committedOn).to.be.equal('1437984179');
 			expect(commit.author.name).to.be.equal('Author1');
@@ -66,7 +64,7 @@ describe('feature: git-last-commit to return last commit info', function() {
 	});
 
 	it('should parse git commands when commit has no body', function(done) {
-		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\nR2\nR1');
+		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\nR2\nR1');
 
 		git.getLastCommit(function(err, commit) {
 			expect(err).to.be.null;
@@ -75,7 +73,6 @@ describe('feature: git-last-commit to return last commit info', function() {
 			expect(commit.hash).to.be.equal('26e689d8769908329a145201be5081233c711663');
 			expect(commit.subject).to.be.equal('initial commit');
 			expect(commit.sanitizedSubject).to.be.equal('initial-commit');
-			expect(commit.body).to.be.empty;
 			expect(commit.authoredOn).to.be.equal('1437984178');
 			expect(commit.committedOn).to.be.equal('1437984179');
 			expect(commit.author.name).to.be.equal('Author1');
@@ -91,7 +88,7 @@ describe('feature: git-last-commit to return last commit info', function() {
 	});
 
 	it('should parse git commands when commit has no tags', function(done) {
-		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,this is the body,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\n');
+		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\n');
 
 		git.getLastCommit(function(err, commit) {
 			expect(err).to.be.null;
@@ -100,7 +97,6 @@ describe('feature: git-last-commit to return last commit info', function() {
 			expect(commit.hash).to.be.equal('26e689d8769908329a145201be5081233c711663');
 			expect(commit.subject).to.be.equal('initial commit');
 			expect(commit.sanitizedSubject).to.be.equal('initial-commit');
-			expect(commit.body).to.be.equal('this is the body');
 			expect(commit.authoredOn).to.be.equal('1437984178');
 			expect(commit.committedOn).to.be.equal('1437984179');
 			expect(commit.author.name).to.be.equal('Author1');
@@ -116,23 +112,22 @@ describe('feature: git-last-commit to return last commit info', function() {
 	});
 
 	it('should work with approved tags in the commit body', function(done){
-		processExecMethod.yields(null,"fcce488,fcce4881389bf2e6acd33a981dda11f6e44804c9,Commit approved in a PR (pull request #16),commit-approved-in-a-pull-request,Commit approved, one of the commits in the PR,,Approved-by: First User <first.user@test.com>,Approved-by: Second User <second.user@test.com>,Approved-by: Third User <third.user@test.com>,,1496996469,1496996469,User That Commited,user.that.commited@test.com,User That Commited,user.that.commited@test.com,,master,");
+		processExecMethod.yields(null,"fcce488,fcce4881389bf2e6acd33a981dda11f6e44804c9,Merged in master (pull request #16),merged-in-master-16,1496996469,1496996469,User That Committed,user.commited@test.com,Author of Commit,author.commit@test.com,,HEAD,");
 		
 		git.getLastCommit(function(err, commit) {
 			expect(err).to.be.null;
 			expect(commit).to.be.ok;
 			expect(commit.shortHash).to.be.equal('fcce488');
 			expect(commit.hash).to.be.equal('fcce4881389bf2e6acd33a981dda11f6e44804c9');
-			expect(commit.subject).to.be.equal('Commit approved in a PR (pull request #16)');
-			expect(commit.sanitizedSubject).to.be.equal('commit-approved-in-a-pull-request');
-			expect(commit.body).to.be.equal('Commit approved');
+			expect(commit.subject).to.be.equal('Merged in master (pull request #16)');
+			expect(commit.sanitizedSubject).to.be.equal('merged-in-master-16');
 			expect(commit.authoredOn).to.be.equal('1496996469');
 			expect(commit.committedOn).to.be.equal('1496996469');
-			expect(commit.author.name).to.be.equal('User That Commited');
-			expect(commit.author.email).to.be.equal('user.that.commited@test.com');
-			expect(commit.committer.name).to.be.equal('User That Commited');
-			expect(commit.committer.email).to.be.equal('user.that.commited@test.com');
-			expect(commit.branch).to.be.equal('master');
+			expect(commit.author.name).to.be.equal('User That Committed');
+			expect(commit.author.email).to.be.equal('user.commited@test.com');
+			expect(commit.committer.name).to.be.equal('Author of Commit');
+			expect(commit.committer.email).to.be.equal('author.commit@test.com');
+			expect(commit.branch).to.be.equal('HEAD');
 			expect(commit.notes).to.be.empty;
 			expect(commit.tags).to.be.empty;
 
@@ -141,7 +136,7 @@ describe('feature: git-last-commit to return last commit info', function() {
 	});
 
 	it('should parse git commands fully when commit has single tag', function(done) {
-		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,this is the body,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\nR1');
+		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\nR1');
 
 		git.getLastCommit(function(err, commit) {
 			expect(err).to.be.null;
@@ -150,7 +145,6 @@ describe('feature: git-last-commit to return last commit info', function() {
 			expect(commit.hash).to.be.equal('26e689d8769908329a145201be5081233c711663');
 			expect(commit.subject).to.be.equal('initial commit');
 			expect(commit.sanitizedSubject).to.be.equal('initial-commit');
-			expect(commit.body).to.be.equal('this is the body');
 			expect(commit.authoredOn).to.be.equal('1437984178');
 			expect(commit.committedOn).to.be.equal('1437984179');
 			expect(commit.author.name).to.be.equal('Author1');
@@ -166,7 +160,7 @@ describe('feature: git-last-commit to return last commit info', function() {
 	});
 
 	it('should run the git command on given destination', function(done) {
-		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,this is the body,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\nR2\nR1');
+		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\nR2\nR1');
 
 		git.getLastCommit(function(err, commit) {
 			expect(err).to.be.null;

--- a/test/unit.js
+++ b/test/unit.js
@@ -115,6 +115,31 @@ describe('feature: git-last-commit to return last commit info', function() {
 		});
 	});
 
+	it('should work with approved tags in the commit body', function(done){
+		processExecMethod.yields(null,"fcce488,fcce4881389bf2e6acd33a981dda11f6e44804c9,Commit approved in a PR (pull request #16),commit-approved-in-a-pull-request,Commit approved, one of the commits in the PR,,Approved-by: First User <first.user@test.com>,Approved-by: Second User <second.user@test.com>,Approved-by: Third User <third.user@test.com>,,1496996469,1496996469,User That Commited,user.that.commited@test.com,User That Commited,user.that.commited@test.com,,master,");
+		
+		git.getLastCommit(function(err, commit) {
+			expect(err).to.be.null;
+			expect(commit).to.be.ok;
+			expect(commit.shortHash).to.be.equal('fcce488');
+			expect(commit.hash).to.be.equal('fcce4881389bf2e6acd33a981dda11f6e44804c9');
+			expect(commit.subject).to.be.equal('Commit approved in a PR (pull request #16)');
+			expect(commit.sanitizedSubject).to.be.equal('commit-approved-in-a-pull-request');
+			expect(commit.body).to.be.equal('Commit approved');
+			expect(commit.authoredOn).to.be.equal('1496996469');
+			expect(commit.committedOn).to.be.equal('1496996469');
+			expect(commit.author.name).to.be.equal('User That Commited');
+			expect(commit.author.email).to.be.equal('user.that.commited@test.com');
+			expect(commit.committer.name).to.be.equal('User That Commited');
+			expect(commit.committer.email).to.be.equal('user.that.commited@test.com');
+			expect(commit.branch).to.be.equal('master');
+			expect(commit.notes).to.be.empty;
+			expect(commit.tags).to.be.empty;
+
+			done();
+		});
+	});
+
 	it('should parse git commands fully when commit has single tag', function(done) {
 		processExecMethod.yields(null, '26e689d,26e689d8769908329a145201be5081233c711663,initial commit,initial-commit,this is the body,1437984178,1437984179,Author1,author@gmail.com,Committer1,committer@gmail.com,note 1\nmaster\nR1');
 


### PR DESCRIPTION
I was having an issue with my commits that were generated by a PR approval, because the came with tags like ApprovedBy <nameOfTheApprover> and also when the branch that is merge has more than one commit what also include more lines in the body .
I believe the body has new tags and it was making the parse misplace the values. 