### PR TITLE
add TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+  export interface Commit {
+    shortHash: string;
+    hash: string;
+    subject: string;
+    sanitizedSubject: string;
+    body: string;
+    authoredOn: string;
+    committedOn: string;
+    author: {
+      name: string;
+      email: string;
+    },
+    committer: {
+      name: string;
+      email: string;
+    },
+    notes?: string;
+    branch: string;
+    tags: string[];
+  }
+
+  type GetLastCommitCallback = (err: Error, commit: Commit) => void;
+  
+  export const getLastCommit: (callback: GetLastCommitCallback) => void;
+  


### PR DESCRIPTION
The "Commit" interface is based on what's in the README.md, it's possible it's incomplete or some of the field should be optional.