### PR TITLE
Fix missing options parameter in index.d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,25 +1,27 @@
-  export interface Commit {
-    shortHash: string;
-    hash: string;
-    subject: string;
-    sanitizedSubject: string;
-    body: string;
-    authoredOn: string;
-    committedOn: string;
-    author: {
-      name: string;
-      email: string;
-    },
-    committer: {
-      name: string;
-      email: string;
-    },
-    notes?: string;
-    branch: string;
-    tags: string[];
-  }
+export interface Commit {
+  shortHash: string;
+  hash: string;
+  subject: string;
+  sanitizedSubject: string;
+  body: string;
+  authoredOn: string;
+  committedOn: string;
+  author: {
+    name: string;
+    email: string;
+  },
+  committer: {
+    name: string;
+    email: string;
+  },
+  notes?: string;
+  branch: string;
+  tags: string[];
+}
+export interface Options {
+  dst: string;
+}
 
-  type GetLastCommitCallback = (err: Error, commit: Commit) => void;
-  
-  export const getLastCommit: (callback: GetLastCommitCallback) => void;
-  
+type GetLastCommitCallback = (err: Error, commit: Commit) => void;
+
+export const getLastCommit: (callback: GetLastCommitCallback, options?: Options) => void;


### PR DESCRIPTION
Issue addressed: https://github.com/seymen/git-last-commit/issues/15

When using this package in TypeScript, it gave an error that function does not accept 2 arguments.
This was due to incorrect definition in the index.s.ts file.
![Screenshot 2021-08-12 at 12 50 29](https://user-images.githubusercontent.com/58426925/129184836-2c95b4da-0475-4e4c-a12e-de5dde9c8e42.png)

I added an interface for options object and added optional argument to this function.