### PR TITLE
Corrected the error argument type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,6 @@ export interface Options {
   dst: string;
 }
 
-type GetLastCommitCallback = (err: Error, commit: Commit) => void;
+type GetLastCommitCallback = (err: Error | null, commit: Commit) => void;
 
 export const getLastCommit: (callback: GetLastCommitCallback, options?: Options) => void;


### PR DESCRIPTION
An always truthy type like that may trigger some people's eslint "no-unnecessary-condition" rules (it triggered mine), so here's a corrected error arg type.