### PR TITLE
return `Error` instead of `string`

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -10,7 +10,7 @@ const executeCommand = (command, options, callback) => {
 
   process.exec(command, {cwd: dst}, function(err, stdout, stderr) {
     if (stdout === '') {
-      callback('this does not look like a git repo')
+      callback(new Error('this does not look like a git repo'))
       return
     }
 


### PR DESCRIPTION
When this error happens, an `Error` should be returned to match Node.js convention.

I was using this library and had some issues related to an error being a string.